### PR TITLE
Add loading overlay to calendar

### DIFF
--- a/nutrimenu-ui/src/components/Calendar.tsx
+++ b/nutrimenu-ui/src/components/Calendar.tsx
@@ -133,11 +133,13 @@ function _CalendarCells({
 export default function Calendar({
     menus,
     currentMonth: currentMonthStr,
-    onMonthChange
+    onMonthChange,
+    loading = false,
 }: {
     menus: MenusSlimByMonth;
     currentMonth: string;
     onMonthChange: (month: string) => void;
+    loading?: boolean;
 }) {
     const [monthState, setMonthState] = useState(
         new Date(currentMonthStr + '-01')
@@ -159,7 +161,12 @@ export default function Calendar({
     }, [menus]);
 
     return (
-        <section className="bg-white rounded-xl shadow p-6">
+        <section className="relative bg-white rounded-xl shadow p-6">
+            {loading && (
+                <div className="absolute inset-0 bg-black/30 flex items-center justify-center z-10">
+                    <div className="bg-white p-4 rounded shadow">Chargement...</div>
+                </div>
+            )}
             <_CalendarHeader
                 currentMonth={monthState}
                 setCurrentMonth={setMonthState}

--- a/nutrimenu-ui/src/pages/HistoryPage.tsx
+++ b/nutrimenu-ui/src/pages/HistoryPage.tsx
@@ -40,6 +40,7 @@ export default function HistoryPage() {
             menus={menusByMonth}
             currentMonth={format(new Date(), "yyyy-MM")}
             onMonthChange={handleMonthChange}
+            loading={loading}
         />
     )
 }


### PR DESCRIPTION
## Summary
- show a popup overlay inside the calendar when data is loading
- pass `loading` state from `HistoryPage` to `Calendar`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d2225540c832685af0f00660f62e5